### PR TITLE
Update oc_rlvextension.lsl

### DIFF
--- a/src/collar/oc_dialog.lsl
+++ b/src/collar/oc_dialog.lsl
@@ -339,8 +339,9 @@ integer IsUUIDList(list lTmp)
 {
     integer i=0;
     integer end = llGetListLength(lTmp);
+    key item;
     for(i=0;i<end;i++){
-        key item = (key)llList2String(lTmp,i);
+        item = (key)llList2String(lTmp,i);
         if(item) return TRUE;
     }
     return FALSE;
@@ -350,8 +351,9 @@ list SortUUIDList(list lToSort){
     integer i = 0;
     list lIndexNameList = [];
     integer end = llGetListLength(lToSort);
+    string sButton;
     for(i=0;i<end;i++){
-        string sButton = llList2String(lToSort,i);
+        sButton = llList2String(lToSort,i);
         if(IsLikelyAvatar((key)sButton)){
             if(llGetAgentSize((key)sButton)==ZERO_VECTOR)
                 sButton = NameURI((key)sButton);
@@ -564,7 +566,7 @@ state active
 
 
     sensor(integer num_detected){
-        //if(num_detected>16) num_detected=16;
+        if(num_detected>24) num_detected=24;
         //LL just expanded sensor to up to 32 hits. Thanks LL, but there's a ton of content 
         //out there not designed to cope with that which are gonna stack-heap now. For now at least we'll trim back to 16.
         //emergency fix removed with updated memory handling in sortuuid function
@@ -787,3 +789,4 @@ state inUpdate{
         }
     }
 }
+

--- a/src/collar/oc_rlvextension.lsl
+++ b/src/collar/oc_rlvextension.lsl
@@ -62,6 +62,10 @@ Krysten Minx -
 chew -
     Jun 2025    -   Reduced memory footprint: Refactor MuffleText, refactor Dialog, reduce redundant
                     list calls in MenuSetValue, shorten some language strings
+
+Nikki Lacrima   -
+    Oct 2025    -   Respring to parent menu after Force Sit                    
+                    
 */
 string g_sParentMenu = "RLV";
 string g_sSubMenu1 = "Force Sit";
@@ -355,7 +359,7 @@ SetUserExes(key id, integer mask, integer lastmask)
     while(i<7)
     {
         // Equivalent of (1 << i) to test each bit individually
-        maskval=(integer)llPow(2,i);
+        maskval=(1<<i);
         if((mask&maskval)==maskval && (lastmask&maskval)!=maskval) out+=llList2String(lExcepts,i)+":"+(string)id+"=add";
         else if((mask&maskval)!=maskval && (lastmask&maskval)==maskval) out+=llList2String(lExcepts,i)+":"+(string)id+"=rem";
         ++i;
@@ -713,11 +717,8 @@ state active
                     if (sMsg == UPMENU) llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     else{
                         UserCommand(iAuth,"sit "+sMsg,kAv);
-                        
-                        // Time-delayed remenu because the sensor misses the object immediately
-                        // after an unsit. Reopen the menu after 3 seconds so the sensor has
-                        // time to detect the newly stood object.
-                        llMessageLinked(LINK_SET,TIMEOUT_REGISTER,"3","remenu_forcesit:"+(string)kAv+":"+(string)iAuth);
+                        // Respring one level up to reduce crashes also removed TIMEOUT handling
+                        llMessageLinked(LINK_SET, iAuth, "menu "+g_sParentMenu, kAv);
                     }
                 } else if (sMenu == "Settings~Camera") {
                     if (sMsg == UPMENU)llMessageLinked(LINK_SET, iAuth,g_sCameraBackMenu, kAv);
@@ -933,13 +934,6 @@ state active
             if (llList2String(lCMD,0) == "sendchat" && llList2Integer(lCMD,2) < 0) {
                 g_bCanChat = llList2Integer(lCMD,1);
                 SetMuffle(g_bMuffle);
-            }
-        } else if (iNum == TIMEOUT_FIRED) {
-            // Timer events from the helper script. Currently used to
-            // re-open the force sit menu after an unsit.
-            list to=llParseString2List(sStr,[":"],[]);
-            if(llList2String(to,0)=="remenu_forcesit"){
-                MenuForceSit((key)llList2String(to,1), (integer)llList2String(to,2));
             }
         }
     }


### PR DESCRIPTION
Respring to parent menu after Force Sit. 

This improves stability and reduces Stack-Heap issues in oc_dialog, together with reducing maximum sensor results in oc_dialog to 24 tested with three users accessing the Force Sit menu at the same time. 